### PR TITLE
Restrict team actions to admins

### DIFF
--- a/cypress/e2e/admin-permissions.cy.js
+++ b/cypress/e2e/admin-permissions.cy.js
@@ -1,0 +1,90 @@
+describe('Admin permissions API', () => {
+  const timestamp = Date.now();
+  const adminEmail = `admin${timestamp}@example.com`;
+  const memberEmail = `member${timestamp}@example.com`;
+  const password = 'pass123';
+  let adminToken;
+  let memberToken;
+  let adminId;
+  let teamId;
+
+  before(() => {
+    const api = Cypress.env('apiUrl');
+
+    cy.request('POST', `${api}/auth/register`, {
+      name: 'Admin',
+      email: adminEmail,
+      password,
+      role: 'ADMIN',
+    }).then((res) => {
+      adminId = res.body.user.id;
+
+      return cy
+        .request('POST', `${api}/auth/register`, {
+          name: 'Member',
+          email: memberEmail,
+          password,
+          role: 'MEMBER',
+        })
+        .then(() =>
+          cy
+            .request('POST', `${api}/auth/login`, {
+              email: adminEmail,
+              password,
+            })
+            .its('body.token')
+        );
+    })
+      .then((token) => {
+        adminToken = token;
+        return cy
+          .request('POST', `${api}/auth/login`, {
+            email: memberEmail,
+            password,
+          })
+          .its('body.token');
+      })
+      .then((token) => {
+        memberToken = token;
+        return cy.request({
+          method: 'POST',
+          url: `${api}/teams`,
+          headers: { Authorization: `Bearer ${adminToken}` },
+          body: { name: `Team ${timestamp}` },
+        });
+      })
+      .then((res) => {
+        teamId = res.body.id;
+      });
+  });
+
+  it('rejects team creation by non-admin', () => {
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('apiUrl')}/teams`,
+      headers: { Authorization: `Bearer ${memberToken}` },
+      body: { name: `Nope ${timestamp}` },
+      failOnStatusCode: false,
+    }).its('status').should('eq', 403);
+  });
+
+  it('rejects board creation by non-admin', () => {
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('apiUrl')}/teams/${teamId}/boards`,
+      headers: { Authorization: `Bearer ${memberToken}` },
+      body: { title: 'New Board' },
+      failOnStatusCode: false,
+    }).its('status').should('eq', 403);
+  });
+
+  it('rejects invites by non-admin', () => {
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('apiUrl')}/teams/${teamId}/invite`,
+      headers: { Authorization: `Bearer ${memberToken}` },
+      body: { userId: adminId },
+      failOnStatusCode: false,
+    }).its('status').should('eq', 403);
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -7,11 +7,12 @@ Cypress.Commands.add('login', (email, password) => {
     });
 });
 
-Cypress.Commands.add('register', (name, email, password) => {
+Cypress.Commands.add('register', (name, email, password, role = 'ADMIN') => {
   const apiUrl = Cypress.env('apiUrl') || 'http://localhost:5555/api';
   cy.request('POST', `${apiUrl}/auth/register`, {
     name,
     email,
     password,
+    role,
   });
 });

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -5,7 +5,7 @@ const prisma = require('../prisma/client');
 const JWT_SECRET = process.env.JWT_SECRET;
 
 exports.register = async (req, res) => {
-  const { email, password, name } = req.body;
+  const { email, password, name, role } = req.body;
 
   try {
     const existing = await prisma.user.findUnique({ where: { email } });
@@ -18,7 +18,7 @@ exports.register = async (req, res) => {
         email,
         password: hashed,
         name,
-        role: 'ADMIN',
+        ...(role ? { role } : {}),
       },
     });
 

--- a/src/middleware/admin.middleware.js
+++ b/src/middleware/admin.middleware.js
@@ -1,0 +1,6 @@
+module.exports = function (req, res, next) {
+  if (req.user && req.user.role === 'ADMIN') {
+    return next();
+  }
+  return res.status(403).json({ error: 'Admin access required' });
+};

--- a/src/routes/board.routes.js
+++ b/src/routes/board.routes.js
@@ -2,8 +2,9 @@ const express = require('express');
 const router = express.Router({ mergeParams: true });
 const boardController = require('../controllers/board.controller');
 const authMiddleware = require('../middleware/auth.middleware');
+const adminMiddleware = require('../middleware/admin.middleware');
 
-router.post('/:teamId/boards', authMiddleware, boardController.createBoard);
+router.post('/:teamId/boards', authMiddleware, adminMiddleware, boardController.createBoard);
 router.get('/:teamId/boards', authMiddleware, boardController.getBoardsByTeam);
 
 module.exports = router;

--- a/src/routes/team.routes.js
+++ b/src/routes/team.routes.js
@@ -2,10 +2,21 @@ const express = require('express');
 const router = express.Router();
 const teamController = require('../controllers/team.controller');
 const authMiddleware = require('../middleware/auth.middleware');
+const adminMiddleware = require('../middleware/admin.middleware');
 
-router.post('/', authMiddleware, teamController.createTeam);
+router.post('/', authMiddleware, adminMiddleware, teamController.createTeam);
 router.get('/my', authMiddleware, teamController.getMyTeam);
-router.post('/:teamId/invite', authMiddleware, teamController.inviteUser);
-router.post('/:teamId/invite-by-email', authMiddleware, teamController.inviteByEmail);
+router.post(
+  '/:teamId/invite',
+  authMiddleware,
+  adminMiddleware,
+  teamController.inviteUser
+);
+router.post(
+  '/:teamId/invite-by-email',
+  authMiddleware,
+  adminMiddleware,
+  teamController.inviteByEmail
+);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add middleware to enforce admin role
- secure team/board routes with admin middleware
- allow optional role during registration
- expose optional `role` param in Cypress commands
- test admin permissions with Cypress
- fix admin token retrieval in Cypress test
- fix role handling in user registration
- fix admin test registration

## Testing
- `npm test` *(fails: cypress: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874edaff500832483fb0e9a33250237