### PR TITLE
Add websocket chat feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains a simple full‑stack application that demonstrates a s
 - Manage teams: create teams, invite members by user ID or email, list your teams
 - Boards inside teams: create boards and list boards for a team
 - Tasks inside boards: create, update and delete tasks, assign members and change task status (todo / in‑progress / done)
+- Real-time team chat using WebSockets
 
 ## Getting Started
 

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "socket.io-client": "^4.7.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,7 @@ import Login from './pages/Login';
 import TeamPage from './pages/TeamPage';
 import BoardPage from './pages/BoardPage';
 import TaskPage from './pages/TaskPage';
+import ChatPage from './pages/ChatPage';
 
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(!!localStorage.getItem('token'));
@@ -37,9 +38,14 @@ function App() {
               </Button>
             )}
             {isLoggedIn ? (
-              <Button color="inherit" onClick={handleLogout}>
-                Logout
-              </Button>
+              <>
+                <Button color="inherit" component={Link} to="/chat">
+                  Chat
+                </Button>
+                <Button color="inherit" onClick={handleLogout}>
+                  Logout
+                </Button>
+              </>
             ) : (
               <Button color="inherit" component={Link} to="/login">
                 Login
@@ -59,6 +65,7 @@ function App() {
             <Route path="/teams" element={<TeamPage />} />
             <Route path="/teams/:teamId/boards" element={<BoardPage />} />
             <Route path="/boards/:boardId/tasks" element={<TaskPage />} />
+            <Route path="/chat" element={<ChatPage />} />
           </Routes>
         </Container>
       </Box>

--- a/client/src/pages/ChatPage.jsx
+++ b/client/src/pages/ChatPage.jsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import io from 'socket.io-client';
+import { Box, TextField, Button, Typography, List, ListItem } from '@mui/material';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5555/api';
+const SOCKET_URL = API_URL.replace('/api', '');
+const socket = io(SOCKET_URL);
+
+function ChatPage() {
+  const [messages, setMessages] = useState([]);
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    socket.on('messages', (msgs) => setMessages(msgs));
+    socket.on('new-message', (msg) => {
+      setMessages((prev) => [...prev, msg]);
+    });
+    return () => {
+      socket.off('messages');
+      socket.off('new-message');
+    };
+  }, []);
+
+  const send = () => {
+    const token = localStorage.getItem('token');
+    if (!content.trim() || !token) return;
+    socket.emit('send-message', { token, content });
+    setContent('');
+  };
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Typography variant="h5" gutterBottom>
+        Team Chat
+      </Typography>
+      <List sx={{ mb: 2 }}>
+        {messages.map((m) => (
+          <ListItem key={m.id} sx={{ display: 'block' }}>
+            <strong>{m.user?.name || 'Unknown'}:</strong> {m.content}
+          </ListItem>
+        ))}
+      </List>
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <TextField
+          fullWidth
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Type a message"
+        />
+        <Button variant="contained" onClick={send}>
+          Send
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+export default ChatPage;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@
 require('dotenv').config();
 
 const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const jwt = require('jsonwebtoken');
+const prisma = require('./src/prisma/client');
 const app = express();
+const server = http.createServer(app);
+const io = new Server(server, { cors: { origin: '*' } });
 const PORT = process.env.PORT || 3000;
 const cors = require('cors');
 
@@ -12,6 +18,7 @@ const authRoutes = require('./src/routes/auth.routes');
 const teamRoutes = require('./src/routes/team.routes');
 const boardRoutes = require('./src/routes/board.routes');
 const taskRoutes = require('./src/routes/task.routes');
+const messageRoutes = require('./src/routes/message.routes');
 
 app.use(express.json());
 
@@ -21,7 +28,29 @@ app.use('/api/auth', authRoutes);
 app.use('/api/teams', teamRoutes);
 app.use('/api/teams', boardRoutes);
 app.use('/api/boards', taskRoutes);
+app.use('/api/messages', messageRoutes);
 
-app.listen(PORT, () => {
+io.on('connection', async (socket) => {
+  const messages = await prisma.message.findMany({
+    orderBy: { createdAt: 'asc' },
+    include: { user: { select: { id: true, name: true } } },
+  });
+  socket.emit('messages', messages);
+
+  socket.on('send-message', async ({ token, content }) => {
+    try {
+      const { userId } = jwt.verify(token, process.env.JWT_SECRET);
+      const message = await prisma.message.create({
+        data: { content, userId },
+        include: { user: { select: { id: true, name: true } } },
+      });
+      io.emit('new-message', message);
+    } catch (err) {
+      console.error('[SOCKET_MESSAGE]', err);
+    }
+  });
+});
+
+server.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.27.1",

--- a/src/controllers/message.controller.js
+++ b/src/controllers/message.controller.js
@@ -1,0 +1,14 @@
+const prisma = require('../prisma/client');
+
+exports.getMessages = async (req, res) => {
+  try {
+    const messages = await prisma.message.findMany({
+      orderBy: { createdAt: 'asc' },
+      include: { user: { select: { id: true, name: true } } },
+    });
+    res.json(messages);
+  } catch (err) {
+    console.error('[GET_MESSAGES]', err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+};

--- a/src/routes/message.routes.js
+++ b/src/routes/message.routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const messageController = require('../controllers/message.controller');
+const authMiddleware = require('../middleware/auth.middleware');
+
+router.get('/', authMiddleware, messageController.getMessages);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- implement socket.io server and chat logic
- expose messages REST endpoint
- add chat page with socket.io client
- link chat page in the UI
- document new realtime chat feature in README

## Testing
- `npm test` *(fails: cypress not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6875e6b107c4832481820ff554c44023